### PR TITLE
use govcmsdev/gitlab-ci image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: integratedexperts/circleci2-builder
+image: govcmsdev/gitlab-ci
 services:
 - docker:dind
 stages:


### PR DESCRIPTION
Update the govcms8 paas scaffold to use the same `govcmsdev/gitlab-ci` image as saas