### PR TITLE
Drush alias wildcard

### DIFF
--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -1,0 +1,1 @@
+# Drush settings.

--- a/drush/sites/feature.site.yml
+++ b/drush/sites/feature.site.yml
@@ -1,0 +1,15 @@
+##
+# Wildcard alias for feature branches.
+# If your branch is feature/foobar, you can run `drush @feature.foobar st`.
+#
+# See WIKI LINK TBA
+#
+
+'*':
+  root: /app
+  host: ssh-lagoon.govcms.amazee.io
+  user: LAGOON_PROJECT-feature-${env-name}
+  uri: LAGOON_PROJECT-feature-${env-name}.govcms.amazee.io
+  ssh:
+    options: -p 30831
+    tty: false


### PR DESCRIPTION
For an existing environment like `feature/unicorn`, allow running `drush @feature.unicorn st`

LAGOON_PROJECT could be replaced in scaffold set up.

I'm not sure why there is no drush folder to start with, maybe there is a conflict here with what the scaffolding playbook does for a new site.

This is not a fix-all for a drush alias service, but seems to be a no-brainer.