### PR TITLE
WIP: Get Gitlab CI rolling again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,5 +6,5 @@ include:
 
   # The primary default GovCMS GitLab CI configuration.
   - project: 'govcms/scaffold-tooling'
-    ref: "0.1.2"
+    ref: "1.0.0"
     file: '.gitlab-ci-main.yml'


### PR DESCRIPTION
Gitlab CI hasn't been running for the scaffold for a couple of months. Not sure what the issue was prior to #12 but now it's a bad scaffold-tooling reference. Let's see what we can do.