### PR TITLE
Prepare v1.1.1 release

### DIFF
--- a/.version.yml
+++ b/.version.yml
@@ -5,4 +5,4 @@
 # e.g. site audits, automated backups.
 version: 8
 type: paas
-scaffold: 1.1.0
+scaffold: 1.1.1


### PR DESCRIPTION
## Release v1.1.1
This is the first release using the improved release process, including tagged releases and communicated release notes.

### Release notes
- Bugfix release: Resolves issue where Drush does not always execute in the correct location