### PR TITLE
Add the custom directory before composer install.

### DIFF
--- a/.docker/Dockerfile.cli
+++ b/.docker/Dockerfile.cli
@@ -14,6 +14,7 @@ RUN rm -rf /app
 
 COPY composer.json composer.lock /app/
 COPY scripts /app/scripts
+COPY custom /app/custom
 
 # Run composer. Additional `rm`s can be added to reduce the image size, with diminishing returns.
 RUN composer install --no-dev --no-interaction --no-suggest \


### PR DESCRIPTION
- Composer install requires the `custom/composer/patches.json` if this is not present during install it errors.