### PR TITLE
Fixed `ahoy refresh-db` command not using newly pulled DB image.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -104,7 +104,7 @@ commands:
     cmd: |
       ahoy confirm "Running this command will replace your current database. Are you sure?" &&
       # Run this if confirm returns true
-      cat .env | grep MARIADB_DATA_IMAGE | cut -c20- | xargs -n1 docker pull && ahoy up ||
+      cat .env | grep MARIADB_DATA_IMAGE | cut -c20- | xargs -n1 docker pull && docker-compose rm -f -s -v mariadb && ahoy up ||
       # Run this if confirm returns false
       echo "OK, probably a wise choice..."
 


### PR DESCRIPTION
Currently, `ahoy refresh-db` script pulls the latest DB image and starts the stack. As a part of this process, it is expected for the newly pulled DB image to be used for the DB container.
However, this will only work if there is no local container already running or stopped.

If there is a running or stopped container, `docker-compose up` will just start it from the existing image, not the newly pulled one.

The change in this PR actually stops and removes the `mariadb` container before the stack is started, which is what this commands claim to do.