### PR TITLE
Updated lagoon to use unified govcms-deploy script.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -10,17 +10,17 @@ environments:
         command: 'drush cron --root=/app'
         service: cli
 
-# Note regarding tasks in the scaffold.
 # Please avoid making scripts more than one or two lines, and avoid if/else logic.
-# When PaaS users or the support team modify this file, it should be easy to turn things on and off.
+# When PaaS users or the support team modify this file, it should be easy to
+# turn things on and off.
 
 tasks:
   pre-rollout:
     - run:
-        name: Ensure backup folder exists - not all current envs have one
+        name: Ensure backup folder exists
         command: mkdir -p /app/web/sites/default/files/private/backups
         service: cli
-        shell: bash    
+        shell: bash
     - run:
         name: Snapshot the database and store
         command: if [[ "$LAGOON_ENVIRONMENT_TYPE" = "production" ]]; then drush sql:dump --root=/app --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql; fi
@@ -33,49 +33,63 @@ tasks:
         shell: bash
 
   post-rollout:
+    # Use unified deployment script to run post-rollout commands. This script
+    # is called in all environments and guarantees that the order of deployment
+    # commands is persistent and predictable.
+    # https://github.com/govCMS/scaffold-tooling/blob/master/scripts/govcms-deploy
+    #
+    # If you need to customise the deployment process, feel free to remove
+    # the run of the unified script and use custom steps conveniently provided
+    # below (please note that by doing so GovCMS support may not be able to
+    # resolve deployment issues as efficiently as if the unified deployment
+    # script is used).
     - run:
-        name: Correct legacy drush alias if necessary
-        command: sed -i "s/%%PROJECT_NAME%%/\${env.LAGOON_PROJECT}/g" /app/drush/sites/govcms.site.yml
+        name: Deploy GovCMS
+        command: ./vendor/bin/govcms-deploy
         service: cli
-        shell: bash
-    - run:
-        name: Ensure backup folder exists
-        command: mkdir -p /app/web/sites/default/files/private/backups
-        service: cli
-        shell: bash
-    - run:
-        name: If a new environment populate database from master
-        command: drush status db-status | grep Connected || if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush sql:sync @govcms.prod @self -y; fi
-        service: cli
-        shell: bash
-    - run:
-        name: Perform database updates
-        command: drush -y updatedb
-        service: cli
-        shell: bash
-    - run:
-        name: Perform config import (uncomment to enable)
-        command: |
-          # drush cim -y sync && if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush cim -y --partial --source=../config/dev; fi
-        service: cli
-        shell: bash
-    - run:
-        name: Perform cache rebuild
-        command: drush -y cr
-        service: cli
-        shell: bash
-    - run:
-        name: Ensure GovCMS/Lagoon modules are enabled
-        command: drush en -y govcms_lagoon && drush pmu -y govcms_lagoon
-        service: cli
-        shell: bash
-    - run:
-        name: Enable any non-production modules
-        command: if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush en stage_file_proxy -y; fi
-        service: cli
-        shell: bash
-    - run:
-        name: Preserve the last successful backup
-        command: export BACKUP="/app/web/sites/default/files/private/backups/pre-deploy-dump" && mv "$BACKUP.sql.gz" "$BACKUP-last-good.sql.gz" || true
-        service: cli
-        shell: bash
+    # - run:
+    #     name: Correct legacy drush alias if necessary
+    #     command: sed -i "s/%%PROJECT_NAME%%/\${env.LAGOON_PROJECT}/g" /app/drush/sites/govcms.site.yml
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: Ensure backup folder exists
+    #     command: mkdir -p /app/web/sites/default/files/private/backups
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: If a new environment populate database from master
+    #     command: drush status db-status | grep Connected || if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush sql:sync @govcms.prod @self -y; fi
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: Perform database updates
+    #     command: drush -y updatedb
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: Perform config import (uncomment to enable)
+    #     command: |
+    #       # drush cim -y sync && if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush cim -y --partial --source=../config/dev; fi
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: Perform cache rebuild
+    #     command: drush -y cr
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: Ensure GovCMS/Lagoon modules are enabled
+    #     command: drush en -y govcms_lagoon && drush pmu -y govcms_lagoon
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: Enable any non-production modules
+    #     command: if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then drush en stage_file_proxy -y; fi
+    #     service: cli
+    #     shell: bash
+    # - run:
+    #     name: Preserve the last successful backup
+    #     command: export BACKUP="/app/web/sites/default/files/private/backups/pre-deploy-dump" && mv "$BACKUP.sql.gz" "$BACKUP-last-good.sql.gz" || true
+    #     service: cli
+    #     shell: bash


### PR DESCRIPTION
Reverts Lagoon deployment to use unified `govcms-deploy` script from `scaffold-tooling` repo while providing some starter code for deployment overrides.

In this way we, as new project creators, can guarantee that *exactly the same* deployment procedures used in all environments, and they all controlled from a single place - a version of `scaffold-tooling` repository.

In the future, we would update `govcms-deploy` script to be controlled by the environment variables, so that Lagoon deployment can still reference the same 100% tested script.