### PR TITLE
Allow enable/disable DEV_MODE in any environment

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -46,7 +46,6 @@
 /* @var $govcms_env string */
 
 $govcms_includes = $app_root . '/../vendor/govcms/scaffold-tooling/drupal/settings';
-$govcms_is_prod = !getenv('DEV_MODE') && (getenv('LAGOON_ENVIRONMENT_TYPE') && getenv('LAGOON_ENVIRONMENT_TYPE') == 'production');
 
 include $govcms_includes . '/all.settings.php';
 
@@ -56,10 +55,11 @@ if (getenv('LAGOON')) {
 }
 
 // Prod vs Dev specific overrides.
-if ($govcms_is_prod) {
+if (getenv('LAGOON_ENVIRONMENT_TYPE') && getenv('LAGOON_ENVIRONMENT_TYPE') == 'production') {
   include $govcms_includes . '/production.settings.php';
 }
-else {
+
+if (getenv('DEV_MODE') && getenv('DEV_MODE') == 'true') {
   include $govcms_includes . '/development.settings.php';
 }
 


### PR DESCRIPTION
At the moment it is not possible to control the `DEV_MODE` flag, it is bound to the `LAGOON_ENVIRONMENT_TYPE`.

In many instances you may wish to enable or disable `DEV_MODE` in environments other than production (or _even_ production during early development days/debugging).

Requires [1.0.1 release](https://github.com/govCMS/scaffold-tooling/pull/34) of scaffold tooling, otherwise `development.settings.php` gets included either way (already included in https://github.com/govCMS/scaffold-tooling/blob/master/drupal/settings/lagoon.settings.php)