### PR TITLE
Update "symfony/event-dispatcher" in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "govcms/custom": "*",
         "govcms/govcms": "~1",
         "govcms/scaffold-tooling": "~2",
-        "symfony/event-dispatcher": "4.3.11 as 3.4.35"
+        "symfony/event-dispatcher": "4.3.11 as 3.4.41"
     },
     "require-dev": {
         "govcms/require-dev": "~1"


### PR DESCRIPTION
Update `"symfony/event-dispatcher": "4.3.11 as 3.4.41"` for the Drupal 8.9.1 requirements