### PR TITLE
[GOVCMS-5020] Setup local overrides for removal in CI.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     # Mount volumes from Pygmy to inject host SSH key into container.
     # https://pygmy.readthedocs.io/en/master/ssh_agent/
     volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
-      - container:amazeeio-ssh-agent
+      - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
 
   test:
     build:


### PR DESCRIPTION
Pygmy is used on local dev environment so `amazeeio-ssh-agent` is not available in CI. This PR adds a comment prefixed with `###` so we can remove the override in CI. See: https://github.com/govCMS/scaffold-tooling/pull/63.